### PR TITLE
Updated expo to v37

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "expo-crypto": "~8.0.0",
     "expo-file-system": "~8.0.0",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.1.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
Your library is failing on iOS on my project with latest expo v37, after update of expo it works great, thanks for your work!